### PR TITLE
Test build with x86 Mac (not 64bit)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,12 @@ include mk/osdetect.mk
 # rules
 openssl:
 	$(MAKE) -C ports/thirdparty/libressl do-install
+ifeq ($(OPSYS),Darwin)
+readline: ;
+else
 readline:
 	$(MAKE) -C ports/thirdparty/readline do-install
+endif
 ifeq ($(OPSYS),Darwin)
 zlib: ;
 else

--- a/ports/pacbio/pbbam/Makefile
+++ b/ports/pacbio/pbbam/Makefile
@@ -23,6 +23,7 @@ do-config: do-extract
 	@cd $(_WRKSRC) && mkdir -p build
 	@cd $(_WRKSRC)/build && \
         cmake \
+            -D PacBioBAM_build_shared=ON \
             -D GTEST_SRC_DIR=$(PREFIX)/src/gtest \
             -D HTSLIB_ROOTDIR=$(PREFIX)/src/htslib \
             ..

--- a/ports/thirdparty/samtools/Makefile
+++ b/ports/thirdparty/samtools/Makefile
@@ -12,6 +12,10 @@ do-fetch: wscheck
 	@test -e $(_NAME).tar.bz2 || $(CURL) -L -O $(_URL)/$(_NAME).tar.bz2
 	@which $(MD5SUM) >& /dev/null && $(MD5SUM) -c MD5SUM
 do-config: do-extract
+ifeq ($(OPSYS),Darwin)
+	@test -e $(_WRKSRC)/config.log || cat patch-01 | (cd $(_WRKSRC) && patch -p0)
+	@test -e $(_WRKSRC)/config.log || perl -pi -e 's/-rdynamic//g' $(_WRKSRC)/Makefile $(_WRKSRC)/htslib-*/configure*
+endif
 	@cd $(_WRKSRC) && test -e config.log || CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" ./configure --prefix=$(STAGING)/$(_NAME)
 do-build: do-config
 	@test -e $(PREFIX)/var/pkg/$(_NAME) || $(MAKE) -C $(_WRKSRC) >& build.log

--- a/ports/thirdparty/samtools/patch-01
+++ b/ports/thirdparty/samtools/patch-01
@@ -1,0 +1,63 @@
+--- bam_addrprg.c.bak	2015-09-15 07:46:01.000000000 -0700
++++ bam_addrprg.c	2016-01-02 18:51:40.000000000 -0800
+@@ -474,3 +474,60 @@
+ 
+     return EXIT_FAILURE;
+ }
++
++/*      $NetBSD: strndup.c,v 1.3 2007/01/14 23:41:24 cbiere Exp $       */
++
++/*
++ * Copyright (c) 1988, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++/*
++#include <sys/cdefs.h>
++__FBSDID("$FreeBSD: src/lib/libc/string/strndup.c,v 1.1 2008/12/06 09:37:54 kib Exp $");
++
++#include <stddef.h>
++#include <stdlib.h>
++#include <string.h>
++*/
++
++char *
++strndup(const char *str, size_t n)
++{
++	size_t len;
++	char *copy;
++
++	for (len = 0; len < n && str[len]; len++)
++		continue;
++
++	if ((copy = malloc(len + 1)) == NULL)
++		return (NULL);
++	memcpy(copy, str, len);
++	copy[len] = '\0';
++	return (copy);
++}
++


### PR DESCRIPTION
Still not working, see if we can get clang working first. the patch-01 (BSD Licensed.) is not needed on OS X 10.10+